### PR TITLE
Fix for July 25, 2023 TF2 Update (100 players support)

### DIFF
--- a/pkg/g15/g15.go
+++ b/pkg/g15/g15.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const maxDataSize = 34
+const maxDataSize = 102
 
 type DumpPlayer struct {
 	Names     [maxDataSize]string


### PR DESCRIPTION
https://www.teamfortress.com/post.php?id=206934
On July 25, 2023, an experimental feature was added to support 100 players, since then 'g15_dumpplayers' returns a larger dataset even on regular servers.

This change fixes the crash. I don't see any other issues caused by the update.

As you know there are performance impacts related to printing to console and rcon responses, and this one is now pretty damn large.
Have you considered disabling some requests if the new information they provide is not currently enabled in the web UI?

Thanks for all of your work!