### PR TITLE
Fix game binary name on linux

### DIFF
--- a/internal/platform/linux.go
+++ b/internal/platform/linux.go
@@ -29,7 +29,7 @@ func New() LinuxPlatform {
 	return LinuxPlatform{
 		defaultSteamRoot:      steamRoot,
 		defaultTF2Root:        tf2Root,
-		binaryName:            "hl2",
+		binaryName:            "hl2_linux",
 		tf2RootValidationFile: "bin/client.so",
 	}
 }


### PR DESCRIPTION
The game binary on linux is named hl2_linux.

Without this, running the tool on linux throws
```
DEBUG	bd	detector/detector.go:497	Failed to query state	{"error": "Invalid ready state", "errorVerbose": "Invalid ready state\ngithub.com/leighmacdonald/bd/internal/detector.init
    /home/rafael/Dev/bd/internal/detector/detector.go:36
runtime.doInit
    /usr/lib/go/src/runtime/proc.go:6525
runtime.doInit
    /usr/lib/go/src/runtime/proc.go:6502
runtime.main
    /usr/lib/go/src/runtime/proc.go:233
runtime.goexit
    /usr/lib/go/src/runtime/asm_amd64.s:1598"}
```
This is because it cannot find the game process

Thank you for all of your work!