### PR TITLE
Use new 64-bit exe name

### DIFF
--- a/platform/windows.go
+++ b/platform/windows.go
@@ -42,7 +42,7 @@ func New() WindowsPlatform {
 	return WindowsPlatform{
 		defaultSteamRoot:      defaultSteamRoot,
 		defaultTF2Root:        defaultTF2Root,
-		binaryName:            "hl2.exe",
+		binaryName:            "tf_win64.exe",
 		tf2RootValidationFile: "bin/client.dll",
 	}
 }


### PR DESCRIPTION
the 64-bit TF2 update changed the name from hl2.exe to tf_win64.exe